### PR TITLE
Fix build warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
             <version>${apache-httpclient.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${apache-commons-io.version}</version>
         </dependency>


### PR DESCRIPTION
The artifact org.apache.commons:commons-io:jar:1.3.2 has been relocated to commons-io:commons-io:jar:1.3.2.