### PR TITLE
Update JaCoCo configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <!--The classes inside this package enabled the usage and testing of the tools. -->
+                        <exclude>com/github/eliflores/tools/clients/*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
Ignore classes under com/github/eliflores/tools/clients/ enable the usage and testing of the tools.