### PR TITLE
Fix CodeQL analysis GitHub action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,13 +1,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [main]
-  schedule:
-    - cron: '0 19 * * 2'
 
 jobs:
   analyze:


### PR DESCRIPTION
Only run the CodeQL analysis workflow on the "pull_request" event and avoid triggering it on the "push" event for Dependabot branches because workflows triggered by Dependabot on the "push" event run with read-only access, and uploading Code Scanning results requires write access.